### PR TITLE
Expose CardIOActivity.EXTRA_USE_PAYPAL_ACTIONBAR_ICON in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The card.io Cordova plugin provides different configurations that could be set a
 |  hideCardIOLogo                  | Boolean  | The card.io logo will not be shown overlaid on the camera. |
 |  useCardIOLogo                   | Boolean  | The card.io logo will be shown instead of the PayPal logo. |
 |  suppressScan                    | Boolean  | Once a card image has been captured but before it has been processed, this value will determine whether to continue processing as usual. |
+| usePaypalActionbarIcon           | Boolean | Use the PayPal icon in the ActionBar |
 
 Integration instructions
 ------------------------

--- a/src/android/CardIOCordovaPlugin.java
+++ b/src/android/CardIOCordovaPlugin.java
@@ -74,6 +74,7 @@ public class CardIOCordovaPlugin extends CordovaPlugin {
         scanIntent.putExtra(CardIOActivity.EXTRA_SUPPRESS_CONFIRMATION, this.getConfiguration(configurations, "suppressConfirmation", false)); // default: false
         scanIntent.putExtra(CardIOActivity.EXTRA_HIDE_CARDIO_LOGO, this.getConfiguration(configurations, "hideCardIOLogo", false)); // default: false
         scanIntent.putExtra(CardIOActivity.EXTRA_SUPPRESS_SCAN, this.getConfiguration(configurations, "suppressScan", false)); // default: false
+        scanIntent.putExtra(CardIOActivity.EXTRA_USE_PAYPAL_ACTIONBAR_ICON, this.getConfiguration(configurations, "usePaypalActionbarIcon", true)); // default: true
         this.cordova.startActivityForResult(this, scanIntent, REQUEST_CARD_SCAN);
     }
 


### PR DESCRIPTION
This allow us to hide the PayPal logo in the confirmation screen. 

I've had no luck using `useCardIOLogo`, to replace the PayPal logo with Card.io logo. Should it work?

Thanks!!